### PR TITLE
specified commit for purescript-halogen

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,8 @@
     "output"
   ],
   "dependencies": {
-    "purescript-halogen": "master"
+      "purescript-halogen": "30e8b2c7174a1eeda73f67cc42c739ca24a1e218",
+      "purescript-prelude": "^0.1.1"
   },
   "devDependencies": {
     "bootstrap": "~3.3.2"


### PR DESCRIPTION
Currently tagged version depends on **master**. It use to cause problems with bower dependencies in slamdata. 

It works with _purescript#v0.7.2_ not _0.7.3_
